### PR TITLE
Add undeclared dependency and fix `main` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hubot-caniuse",
   "version": "1.0.1",
   "description": "A caniuse hubot script",
-  "main": "hubot-caniuse.js",
+  "main": "hubot-caniuse.coffee",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -22,6 +22,7 @@
 
     "dependencies": {
       "fuzzy": "^0.1.0",
+      "lodash": "^3.2.0",
       "request": "^2.51.0"
     },
   "author": "Alex Volkov <git@alexw.me> (http://alexw.me)",


### PR DESCRIPTION
This breaks for me when using hubot 2.11.0. 

Throws `Error loading scripts from npm package - Error: Cannot find module 'hubot-caniuse'` because the `package.main` entry points to a non-existent hubot-caniuse.js
